### PR TITLE
Fix KeyError and ValueError in loadOriginalZoom for empty halo or fuzz data

### DIFF
--- a/illustris_python/snapshot.py
+++ b/illustris_python/snapshot.py
@@ -241,7 +241,16 @@ def loadOriginalZoom(basePath, snapNum, id, partType, fields=None):
 
     # combine and return
     if isinstance(data1, np.ndarray):
+        # protect against empty data
+        if isinstance(data2, dict):
+            return data1
         return np.concatenate((data1,data2), axis=0)
+    
+    # protect against empty data
+    if data1["count"] == 0:
+        return data2
+    elif data2["count"] == 0:
+        return data1
     
     data = {'count':data1['count']+data2['count']}
     for key in data1.keys():


### PR DESCRIPTION
Fix issue where, if no particles of the requested type exist in either the halo or the fuzz, the function `loadOriginalZoom` would raise a KeyError (or ValueError for single fields) due to one of the loaded data sets being only `{"count": 0}`.

Implementation guards against all possible combinations of loaded data:

- Halo data is full data dict, fuzz data is full data dict: Function behaves as before.
- Halo data is ndarray, fuzz data is ndarray: Function behaves as before.
- Halo data is empty, fuzz data is full data dict: The guard catches the empty halo data (line 250: `data1["count"] == 0`) and returns only the fuzz data.
- Halo data is full data dict, fuzz data is empty: The guard catches the empty fuzz data (line 252: `data2["count"] == 0`) and returns only the halo data.
- Halo data is empty, fuzz data is ndarray: Same behavior as if fuzz were full data; guard catches empty halo data (line 250) and returns fuzz data as ndarray.
- Halo data is ndarray, fuzz data is empty: Additional check now catches fuzz data being a dictionary instead of an ndarray and returns only the halo data ndarray.
- Halo data and fuzz data are both empty: The guard catches the empty halo data and returns the empty fuzz data dictionary, resulting in the expected behavior of the function returning `{"count": 0}`.