### PR TITLE
Fix __init__ so that language servers can detect submodules

### DIFF
--- a/illustris_python/__init__.py
+++ b/illustris_python/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["groupcat", "snapshot", "util", "sublink", "lhalotree", "cartesian"]
 
-from . import *
+from . import groupcat, snapshot, util, sublink, lhalotree, cartesian


### PR DESCRIPTION
`from . import *` causes issues with language servers like Pylance, as they can't inspect the imported submodules. This leads to "Import could not be resolved" errors for code like `il.snapshot.*`. Explicitly writing out the import resolves the error!