### PR TITLE
update offsetsPath and BASE_PATH_ILLUSTRIS_1

### DIFF
--- a/illustris_python/groupcat.py
+++ b/illustris_python/groupcat.py
@@ -3,9 +3,10 @@ groupcat.py: File I/O related to the FoF and Subfind group catalogs. """
 from __future__ import print_function
 
 import six
-from os.path import isfile,expanduser
+from os.path import isfile,expanduser,join
 import numpy as np
 import h5py
+from pathlib import Path
 
 
 def gcPath(basePath, snapNum, chunkNum=0):
@@ -21,7 +22,7 @@ def gcPath(basePath, snapNum, chunkNum=0):
 
 def offsetPath(basePath, snapNum):
     """ Return absolute path to a separate offset file (modify as needed). """
-    offsetPath = basePath + '/../postprocessing/offsets/offsets_%03d.hdf5' % snapNum
+    offsetPath = join(Path(basePath).parent, 'postprocessing/offsets/offsets_%03d.hdf5' % snapNum)
 
     return offsetPath
 

--- a/illustris_python/tests/__init__.py
+++ b/illustris_python/tests/__init__.py
@@ -4,7 +4,7 @@
 import os
 import sys
 
-BASE_PATH_ILLUSTRIS_1 = "/n/ghernquist/Illustris/Runs/L75n1820FP"
+BASE_PATH_ILLUSTRIS_1 = "/virgotng/universe/Illustris/L75n1820FP/output/"
 
 # Add path to directory containing 'illustris_python' module
 #    e.g. if this file is in '/n/home00/lkelley/illustris/illustris_python/tests/'


### PR DESCRIPTION
This PR updates the `offsetsPath` determined in `groupcat.offsetsPath()` such that the path no longer goes through output before going to postprocessing. I verified using the tests (i.e., running `nosetests`) that everything functions as expected, regardless if `basePath` ends with a trailing `/` or not. The package `pathlib` comes pre-installed with Python > 3.4.

Note that I also updated `BASE_PATH_ILLUSTRIS_1` to reflect its current location on virgotng. 